### PR TITLE
Add X value randomization for Verilator simulation

### DIFF
--- a/src/wrapper/simulation/verilator/VerilatorWrapper.cpp
+++ b/src/wrapper/simulation/verilator/VerilatorWrapper.cpp
@@ -136,6 +136,7 @@ void VerilatorWrapper::GenerateScript(std::ostringstream& script, const std::str
       script << " --l2-name v";
 #endif
    }
+   script << " --x-assign unique"; // randomize assigned x values
    for(const auto& file : file_list)
    {
       script << " " << file;


### PR DESCRIPTION
Add X value randomization for Verilator simulation

Currently, the Verilator script relies on the default --x-assign fast option,
which converts all assignments to X to the same value - usually 0 -

The added --x-assign unique option instead randomize the assignment conversion
This should provide better bug detection, particularly when testing
X assignment in the FSM controller
