### PR TITLE
Fix some bugs with clang 16 build

### DIFF
--- a/etc/libbambu/libm/Makefile.am
+++ b/etc/libbambu/libm/Makefile.am
@@ -408,8 +408,8 @@ libm_clang16_a_SOURCES = $(common_libm_src) $(common_libm_src_fr)
 libm_clang16_a_CFLAGS = $(compiler_flags_clang_nosub) --compiler=I386_CLANG16
 libm_clang16_a_AR = $(top_builddir)/src/tree-panda-gcc --compiler=I386_CLANG16 $(common_treegccflags_clang) -C
 libm_clang16_std_a_SOURCES = $(common_libm_src) $(common_libm_src_std)
-libm_clang16_std_a_CFLAGS = $(compiler_flags_clang_nosub) --compiler=I386_CLANG13
-libm_clang16_std_a_AR = $(top_builddir)/src/tree-panda-gcc --compiler=I386_CLANG13 $(common_treegccflags_clang) -C
+libm_clang16_std_a_CFLAGS = $(compiler_flags_clang_nosub) --compiler=I386_CLANG16
+libm_clang16_std_a_AR = $(top_builddir)/src/tree-panda-gcc --compiler=I386_CLANG16 $(common_treegccflags_clang) -C
 
 pkglib_LIBRARIES += libm_clang16_subnormals.a libm_clang16_subnormals_std.a
 libm_clang16_subnormals_a_SOURCES = $(common_libm_src) $(common_libm_src_fr)

--- a/src/HLS/simulation/CTestbenchExecution.cpp
+++ b/src/HLS/simulation/CTestbenchExecution.cpp
@@ -149,16 +149,15 @@ DesignFlowStep_Status CTestbenchExecution::Exec()
    const auto default_compiler = parameters->getOption<CompilerWrapper_CompilerTarget>(OPT_default_compiler);
    // NOTE: starting from version 13 on it seems clang is not respecting the -fno-strict-aliasing flag generating
    // incorrect code when type punning is present
-   const auto opt_lvl =
+   const auto opt_lvl = false
 #if HAVE_I386_CLANG13_COMPILER
-       default_compiler == CompilerWrapper_CompilerTarget::CT_I386_CLANG13
+         || default_compiler == CompilerWrapper_CompilerTarget::CT_I386_CLANG13
+#endif
 #if HAVE_I386_CLANG16_COMPILER
-               || default_compiler == CompilerWrapper_CompilerTarget::CT_I386_CLANG16
+         || default_compiler == CompilerWrapper_CompilerTarget::CT_I386_CLANG16
 #endif
-           ?
-           CompilerWrapper_OptimizationSet::O0 :
-#endif
-           CompilerWrapper_OptimizationSet::O2;
+      ? CompilerWrapper_OptimizationSet::O0
+      : CompilerWrapper_OptimizationSet::O2;
    const CompilerWrapperConstRef compiler_wrapper(new CompilerWrapper(parameters, default_compiler, opt_lvl));
 
    std::string compiler_flags = "-fwrapv -flax-vector-conversions -msse2 -mfpmath=sse -fno-strict-aliasing "

--- a/src/HLS/simulation/testbench_values_c_generation.cpp
+++ b/src/HLS/simulation/testbench_values_c_generation.cpp
@@ -176,16 +176,15 @@ DesignFlowStep_Status TestbenchValuesCGeneration::Exec()
    const auto default_compiler = parameters->getOption<CompilerWrapper_CompilerTarget>(OPT_default_compiler);
    // NOTE: starting from version 13 on it seems clang is not respecting the -fno-strict-aliasing flag generating
    // incorrect code when type punning is present
-   const auto opt_lvl =
+   const auto opt_lvl = false
 #if HAVE_I386_CLANG13_COMPILER
-       default_compiler == CompilerWrapper_CompilerTarget::CT_I386_CLANG13
+         || default_compiler == CompilerWrapper_CompilerTarget::CT_I386_CLANG13
+#endif
 #if HAVE_I386_CLANG16_COMPILER
-               || default_compiler == CompilerWrapper_CompilerTarget::CT_I386_CLANG16
+         || default_compiler == CompilerWrapper_CompilerTarget::CT_I386_CLANG16
 #endif
-           ?
-           CompilerWrapper_OptimizationSet::O0 :
-#endif
-           CompilerWrapper_OptimizationSet::O2;
+      ? CompilerWrapper_OptimizationSet::O0
+      : CompilerWrapper_OptimizationSet::O2;
    const CompilerWrapperConstRef compiler_wrapper(new CompilerWrapper(parameters, default_compiler, opt_lvl));
    std::string compiler_flags =
        "-fwrapv -ffloat-store -flax-vector-conversions -msse2 -mfpmath=sse -fno-strict-aliasing "

--- a/src/technology/physical_library/technology_node.hpp
+++ b/src/technology/physical_library/technology_node.hpp
@@ -55,6 +55,7 @@
 #include <ostream>
 #include <string>
 #include <vector>
+#include <map>
 
 /**
  * @name forward declarations


### PR DESCRIPTION
I tried to build #150 but it currently fails if clang 13 is not also enabled. These changes should fix that.

It is probably easier to just copy the changes than to merge this PR.