### PR TITLE
Added enable-multifiles panda-parameter 

### DIFF
--- a/src/HLS/backend/generate_hdl.cpp
+++ b/src/HLS/backend/generate_hdl.cpp
@@ -123,6 +123,6 @@ DesignFlowStep_Status generate_hdl::Exec()
    const auto root_functions = HLSMgr->CGetCallGraphManager()->GetRootFunctions();
    std::transform(root_functions.begin(), root_functions.end(), std::back_inserter(top_circuits),
                   [&](unsigned int top_function) { return HLSMgr->get_HLS(top_function)->top->get_circ(); });
-   HM.hdl_gen(file_name, top_circuits, false, HLSMgr->hdl_files, HLSMgr->aux_files);
+   HM.hdl_gen(file_name, top_circuits, HLSMgr->hdl_files, HLSMgr->aux_files, false);
    return DesignFlowStep_Status::SUCCESS;
 }

--- a/src/HLS/simulation/testbench_generation.cpp
+++ b/src/HLS/simulation/testbench_generation.cpp
@@ -614,7 +614,7 @@ DesignFlowStep_Status TestbenchGeneration::Exec()
    HDL_manager HDLMgr(HLSMgr, HLSMgr->get_HLS_device(), parameters);
    std::list<std::string> hdl_files, aux_files;
    const std::list<structural_objectRef> tb_circuits = {tb_cir};
-   HDLMgr.hdl_gen(tb_filename, tb_circuits, false, hdl_files, aux_files);
+   HDLMgr.hdl_gen(tb_filename, tb_circuits, hdl_files, aux_files, true);
    THROW_ASSERT(hdl_files.size() == 1, "Expected single testbench file");
    THROW_ASSERT(aux_files.size() <= 1, "Expected at most a single testbench aux file");
    if(aux_files.size())

--- a/src/design_flows/backend/ToHDL/HDL_manager.hpp
+++ b/src/design_flows/backend/ToHDL/HDL_manager.hpp
@@ -115,14 +115,14 @@ class HDL_manager
     * Generates the HDL description for the given components in the specified language
     */
    std::string write_components(const std::string& filename, const HDLWriter_Language language,
-                                const std::list<structural_objectRef>& components, bool equation,
+                                const std::list<structural_objectRef>& components,
                                 std::list<std::string>& aux_files) const;
 
    /**
     * Determines the proper language for each component and generates the corresponding HDL descriptions
     */
-   void write_components(const std::string& filename, const std::list<structural_objectRef>& components, bool equation,
-                         std::list<std::string>& hdl_files, std::list<std::string>& aux_files);
+   void write_components(const std::string& filename, const std::list<structural_objectRef>& components,
+                         std::list<std::string>& hdl_files, std::list<std::string>& aux_files, bool tb);
 
    /**
     * Writes the module description.
@@ -130,7 +130,7 @@ class HDL_manager
     * @param cir is the module to be written. The analysis does not consider the inner objects but just one level of the
     * hierarchy.
     */
-   void write_module(const language_writerRef writer, const structural_objectRef cir, bool equation,
+   void write_module(const language_writerRef writer, const structural_objectRef cir,
                      std::list<std::string>& aux_files) const;
 
    /**
@@ -199,22 +199,16 @@ class HDL_manager
     * Generates HDL code.
     * @param file_name is the name to be created
     * @param cirs are the structural objects representing the components to be generated
-    * @param equation specifies if the equation-based version of the component has to be generated
     * @param the created files (file_name + other files)
     * @param the created aux files
     */
-   void hdl_gen(const std::string& filename, const std::list<structural_objectRef>& cirs, bool equation,
-                std::list<std::string>& hdl_files, std::list<std::string>& aux_files);
+   void hdl_gen(const std::string& filename, const std::list<structural_objectRef>& cirs,
+                std::list<std::string>& hdl_files, std::list<std::string>& aux_files, bool tb);
 
    /**
     * Converts a generic string to a language compliant identifier
     */
    static std::string convert_to_identifier(const language_writer* writer, const std::string& id);
-
-   /**
-    * Converts a generic string to a language compliant identifier
-    */
-   static std::string convert_to_identifier(const std::string& id);
 
    /**
     * Returns the module typename taking into account even the flopoco customizations

--- a/src/design_flows/backend/ToHDL/language_writer.hpp
+++ b/src/design_flows/backend/ToHDL/language_writer.hpp
@@ -258,11 +258,6 @@ class language_writer
     */
    virtual void write_module_parametrization(const structural_objectRef& cir) = 0;
    /**
-    * Write the tail part of the file. Write some lines of comments and some debugging code.
-    * @param cir is the top component.
-    */
-   virtual void write_tail(const structural_objectRef& cir) = 0;
-   /**
     * write the declaration of all the states of the finite state machine.
     * @param list_of_states is the list of all the states.
     */

--- a/src/design_flows/backend/ToHDL/writer/VHDL_writer.cpp
+++ b/src/design_flows/backend/ToHDL/writer/VHDL_writer.cpp
@@ -1391,10 +1391,6 @@ void VHDL_writer::write_module_parametrization(const structural_objectRef& cir)
    INDENT_DBG_MEX(DEBUG_LEVEL_VERY_PEDANTIC, debug_level, "<--Written module generics of " + cir->get_path());
 }
 
-void VHDL_writer::write_tail(const structural_objectRef&)
-{
-}
-
 void VHDL_writer::write_state_declaration(const structural_objectRef&, const std::list<std::string>& list_of_states,
                                           const std::string&, const std::string& reset_state, bool one_hot)
 {

--- a/src/design_flows/backend/ToHDL/writer/VHDL_writer.hpp
+++ b/src/design_flows/backend/ToHDL/writer/VHDL_writer.hpp
@@ -181,11 +181,6 @@ struct VHDL_writer : public language_writer
     */
    void write_module_parametrization(const structural_objectRef& cir) override;
    /**
-    * Write the tail part of the file. Write some lines of comments and some debugging code.
-    * @param cir is the top component.
-    */
-   void write_tail(const structural_objectRef& cir) override;
-   /**
     * write the declaration of all the states of the finite state machine.
     * @param list_of_states is the list of all the states.
     */

--- a/src/design_flows/backend/ToHDL/writer/verilog_writer.cpp
+++ b/src/design_flows/backend/ToHDL/writer/verilog_writer.cpp
@@ -1205,10 +1205,6 @@ void verilog_writer::write_module_parametrization(const structural_objectRef& ci
    INDENT_DBG_MEX(DEBUG_LEVEL_VERY_PEDANTIC, debug_level, "<--Written module generics of " + cir->get_path());
 }
 
-void verilog_writer::write_tail(const structural_objectRef&)
-{
-}
-
 void verilog_writer::write_state_declaration(const structural_objectRef& cir,
                                              const std::list<std::string>& list_of_states, const std::string&,
                                              const std::string& reset_state, bool one_hot)

--- a/src/design_flows/backend/ToHDL/writer/verilog_writer.hpp
+++ b/src/design_flows/backend/ToHDL/writer/verilog_writer.hpp
@@ -191,11 +191,6 @@ class verilog_writer : public language_writer
     */
    void write_module_parametrization(const structural_objectRef& cir) override;
    /**
-    * Write the tail part of the file. Write some lines of comments and some debugging code.
-    * @param cir is the top component.
-    */
-   void write_tail(const structural_objectRef& cir) override;
-   /**
     * write the declaration of all the states of the finite state machine.
     * @param list_of_states is the list of all the states.
     */

--- a/src/technology/RTL_characterization.cpp
+++ b/src/technology/RTL_characterization.cpp
@@ -1156,7 +1156,7 @@ void RTLCharacterization::AnalyzeCell(functional_unit* fu, const unsigned int pr
       std::list<std::string> hdl_files, aux_files;
       std::list<structural_objectRef> circuits;
       circuits.push_back(circuit);
-      HDL->hdl_gen(fu_name, circuits, false, hdl_files, aux_files);
+      HDL->hdl_gen(fu_name, circuits, hdl_files, aux_files, false);
       int PipelineDepth = -1;
 #if HAVE_FLOPOCO
       if(n_pipe_parameters > 0 && NPF && NPF->exist_NP_functionality(NP_functionality::FLOPOCO_PROVIDED) &&

--- a/src/wrapper/simulation/SimulationTool.cpp
+++ b/src/wrapper/simulation/SimulationTool.cpp
@@ -368,7 +368,6 @@ std::string SimulationTool::GenerateLibraryBuildScript(std::ostringstream& scrip
    const auto extra_compiler_flags = [&]() {
       std::string flags = " -fwrapv -ffloat-store -flax-vector-conversions -msse2 -mfpmath=sse -fno-strict-aliasing "
                           "-D__builtin_bambu_time_start\\(\\)= -D__builtin_bambu_time_stop\\(\\)= -D__BAMBU_SIM__";
-      flags += " -I" + relocate_compiler_path(PANDA_INCLUDE_INSTALLDIR);
       flags += " -I" + relocate_compiler_path(PANDA_DATA_INSTALLDIR) + "/panda/libmdpi/include";
       if(!Param->isOption(OPT_input_format) ||
          Param->getOption<Parameters_FileFormat>(OPT_input_format) == Parameters_FileFormat::FF_C)


### PR DESCRIPTION
- the panda parameter enable-multifiles change the HDL backend policy. Instead of a single file including all the components, with this parameter enabled, bambu generates one file per component.