### PR TITLE
Fix check for libstdc++fs in the configure script

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1462,11 +1462,11 @@ AC_CONFIG_FILES(ext/Makefile)
 
 ############### Final check for static linking #############################################
 if test "x$panda_ALLSTATIC" = xyes ;then
-  AM_LDFLAGS="-lstdc++fs -all-static -pthread";
+  AM_LDFLAGS="-all-static -pthread";
   LDFLAGS+=" -static";
   AC_SUBST(AM_LDFLAGS)
 else
-  AM_LDFLAGS="-lstdc++fs -pthread";
+  AM_LDFLAGS="-pthread";
 fi
 
 AC_MSG_CHECKING([if std::filesystem requires linking stdc++fs])
@@ -1476,7 +1476,7 @@ AC_LINK_IFELSE(
         #include <filesystem>
         int main() {
             std::error_code ec;
-            std::filesystem::create_directory("/dev/null", &ec);
+            std::filesystem::create_directory("/dev/null", ec);
         }
     ])],
     [ac_cv_fs_stdlib=no],


### PR DESCRIPTION
This PR adjusts the configure script to only explicitly link libstdc++fs when necessary. 

New clang and GCC versions link libstdc++fs by default. The configure script attempts to checks whether a program using the filesystem library compiles without the flag. If it does not, the `-lstdc++fs`  flag is added to the linker flags. However, the check was broken and the test always failed, which results in `-lstdc++fs` always being added. This PR fixes that check, so that the flag is only added when it is actually needed. 

In addition that the `-lstdc++fs` flag was added added again in line 1466 or 1470, which is redundant. This PR fixes that.