### PR TITLE
Use correct compiler for building testbenches

### DIFF
--- a/src/wrapper/simulation/verilator/VerilatorWrapper.cpp
+++ b/src/wrapper/simulation/verilator/VerilatorWrapper.cpp
@@ -180,7 +180,11 @@ std::string VerilatorWrapper::GenerateScript(std::ostream& script, const std::st
        Param->isOption(OPT_verilator_parallel) ? Param->getOption<int>(OPT_verilator_parallel) : 1;
    script << "make -C ${obj_dir}"
           << " -j " << nThreadsMake << " OPT=\"-fstrict-aliasing\""
-          << " -f Vbambu_testbench.mk Vbambu_testbench";
+          << " -f Vbambu_testbench.mk Vbambu_testbench \\\n"
+          << "  CC=${CC} \\\n"
+          << "  CXX=${CC} \\\n"
+          << "  LINK=${CC} \\\n"
+          << "  AR=$(dirname ${CC})/ar";
 #ifdef _WIN32
    /// VM_PARALLEL_BUILDS=1 removes the dependency from perl
    script << " VM_PARALLEL_BUILDS=1 CFG_CXXFLAGS_NO_UNUSED=\"\"";


### PR DESCRIPTION
In recent versions of bambu building the testbenches requires a 32-bit compiler. While the simulation script adds the correct compiler for the first call to make, it does not for the second call, which uses the default systems compiler. This PR overwrites the compiler used for the second call to make with the correct one.